### PR TITLE
Update to more modern alpine and use maven: as base image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,19 +1,9 @@
-FROM jeanblanchard/java:jdk-8
+FROM maven:3.6-jdk-8-alpine
 
 MAINTAINER pjpires@gmail.com
 
 RUN apk add --update \
         linux-headers build-base autoconf automake libtool apr-util apr-util-dev git cmake ninja go openssl
-
-#ARG NETTY_TCNATIVE_TAG=netty-tcnative-parent-2.0.0.Final
-#ENV NETTY_TCNATIVE_TAG $NETTY_TCNATIVE_TAG
-ARG MAVEN_VERSION
-ENV MAVEN_HOME /usr/share/maven
-
-RUN cd /usr/share ; \
-        wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O - | tar xzf - ;\
-        mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven ;\
-        ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
 VOLUME /output
 


### PR DESCRIPTION
We're testing this out right now building 2.0.20 of tcnative in alpine 3.9. Alpine 3.9 comes with openssl 1.1.1, so should work! But will let you know more once fully tested.

In general, just sharing this upstream in case you're interested. :) 